### PR TITLE
Add 'author' attribute to virion.yml

### DIFF
--- a/virion.yml
+++ b/virion.yml
@@ -3,3 +3,4 @@ version: 0.0.0
 antigen: spoondetector
 api: [2.0.0, 3.0.0-ALPHA1, 3.0.0-ALPHA2, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5]
 php: [7.0]
+author: Falk


### PR DESCRIPTION
While spoondetector is under Unlicense, it is a good idea to still declare the author when developers are testing plugins using spoondetector with DEVirion, which will display the author.
The author data may also be injected into the virus-infections.json log in virion hosts in the future.