### PR TITLE
Support 3.0.0-ALPHA6 and 3.0.0-ALPHA7

### DIFF
--- a/virion.yml
+++ b/virion.yml
@@ -1,6 +1,6 @@
 name: SpoonDetector
 version: 0.0.1
 antigen: spoondetector
-api: [2.0.0, 3.0.0-ALPHA1, 3.0.0-ALPHA2, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5]
+api: [2.0.0, 3.0.0-ALPHA1, 3.0.0-ALPHA2, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5, 3.0.0-ALPHA6, 3.0.0-ALPHA7]
 php: [7.0]
 author: Falk


### PR DESCRIPTION
This virion should be still compatible with newer API versions of PocketMine.