### PR TITLE
Remove API version in favor of PHP version (no updates needed)

### DIFF
--- a/virion.yml
+++ b/virion.yml
@@ -1,6 +1,5 @@
 name: SpoonDetector
 version: 0.0.1
 antigen: spoondetector
-api: [2.0.0, 3.0.0-ALPHA1, 3.0.0-ALPHA2, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5, 3.0.0-ALPHA6, 3.0.0-ALPHA7]
-php: [7.0]
+php: [7.0, 7.2]
 author: Falk


### PR DESCRIPTION
In making this change, the virion will not need API updates, and won't need updated until the next major PHP version is released